### PR TITLE
#12256 Improve JVM Arch Detection

### DIFF
--- a/core/bin/service.bat
+++ b/core/bin/service.bat
@@ -13,7 +13,12 @@ if not exist "%JAVA_HOME%\bin\java.exe" (
 echo JAVA_HOME points to an invalid Java installation (no java.exe found in "%JAVA_HOME%"^). Exiting...
 goto:eof
 )
-"%JAVA_HOME%\bin\java" -version 2>&1 | "%windir%\System32\find" "64-Bit" >nul:
+"%JAVA_HOME%\bin\java" -Xmx64M -version 2>&1 | "%windir%\System32\find" "64-Bit" >nul:
+
+if errorlevel 1 (
+	echo Warning: Unable to detect Java version, defaulting to x86  
+	goto x86
+)
 
 if errorlevel 1 goto x86
 set EXECUTABLE=%ES_HOME%\bin\elasticsearch-service-x64.exe


### PR DESCRIPTION
PR for #12256 Notify the user if the JVM architecture could not be detected, instead of silently defaulting to 32-bit. Also add a max heap parameter. On machines with RAM sizes in the order of 64GB plus, the initial heap could be multi-gigabyte. This can lead to an out of memory error when checking for the version.
